### PR TITLE
Improve product grid responsiveness

### DIFF
--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -14,7 +14,6 @@ export default function ProductCard({ product }: Props) {
     <Card className="aspect-[3/4] h-full transition-transform duration-300 ease-in-out hover:-translate-x-1 hover:-translate-y-1 hover:shadow-xl hover:shadow-gray-500">
       {product.images && product.images[0] && (
         <BlockContainer
-          height="7xl"
           width="full"
           className="relative aspect-square"
         >

--- a/ui-framework/theme/grid.ts
+++ b/ui-framework/theme/grid.ts
@@ -5,7 +5,7 @@ export const gridColsClass = {
   4: 'grid-cols-4',
   5: 'grid-cols-5',
   6: 'grid-cols-6',
-  primary: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3',
+  primary: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6',
 };
 
 export const gridGapClass = {


### PR DESCRIPTION
## Summary
- allow grid layout to exceed three columns on larger screens
- let product card images scale with container width

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685235c5ec8c832ab0d2edb5c44a342e